### PR TITLE
Feature/dataflow query

### DIFF
--- a/mcp_settings.json
+++ b/mcp_settings.json
@@ -17,7 +17,10 @@
         "get_parent_classes_by_class_full_name",
         "get_method_by_call_id",
         "get_referenced_method_full_name_by_call_id",
-        "get_calls_in_method_by_method_full_name"
+        "get_calls_in_method_by_method_full_name",
+        "find_flows_from_method_params_to_sink_method",
+        "find_flows_from_source_call_to_sink_call",
+        "find_flows_from_param_index_to_sink_call"
       ],
       "disabled": false,
       "command": "uv",

--- a/server_tools.py
+++ b/server_tools.py
@@ -186,3 +186,71 @@ def get_calls_in_method_by_method_full_name(method_full_name:str) -> list[str]:
     """
     response = joern_remote(f'get_calls_in_method_by_method_full_name("{method_full_name}")')
     return extract_list(response)
+
+@joern_mcp.tool()
+def find_flows_from_method_params_to_sink_method(
+    source_method_full_name: str,
+    sink_method_full_name: str,
+    max_paths: int = 20
+) -> list[str]:
+    """Find taint flow paths from ALL parameters of a source method to calls of a sink method.
+    Use this to check if a method's input can reach a dangerous operation.
+    Each returned string describes one complete path with steps in the form:
+    step0:(type=...|code=...|line=...|id=...) --> step1:(...) --> ...
+    Note: This query may take minutes for large CPGs.
+
+    @param source_method_full_name: Full name of source method (e.g., com.example.Foo.onReceive:void(android.content.Context,android.content.Intent))
+    @param sink_method_full_name: Full name of sink method, exact match (e.g., java.lang.Runtime.exec:Process(String))
+    @param max_paths: Maximum number of flow paths to return (default 20)
+    @return: List of flow path strings, each showing steps from source parameter to sink argument
+    """
+    response = joern_remote(
+        f'find_flows_from_method_params_to_sink_method("{source_method_full_name}", "{sink_method_full_name}", {max_paths})'
+    )
+    return extract_list(response)
+
+@joern_mcp.tool()
+def find_flows_from_source_call_to_sink_call(
+    source_call_name: str,
+    sink_call_name: str,
+    max_paths: int = 20
+) -> list[str]:
+    """Find taint flow paths from return values of calls named source_call_name to calls named sink_call_name.
+    Uses simple name matching (covers all overloads). Useful for Android Intent data tracing.
+    Each returned string describes one complete path with steps in the form:
+    step0:(type=...|code=...|line=...|id=...) --> step1:(...) --> ...
+    Note: This query may take minutes for large CPGs.
+
+    @param source_call_name: Simple method name of source call (e.g., 'getStringExtra', 'getIntExtra')
+    @param sink_call_name: Simple method name of sink call (e.g., 'exec', 'query', 'openFile')
+    @param max_paths: Maximum number of flow paths to return (default 20)
+    @return: List of flow path strings, each showing steps from source to sink
+    """
+    response = joern_remote(
+        f'find_flows_from_source_call_to_sink_call("{source_call_name}", "{sink_call_name}", {max_paths})'
+    )
+    return extract_list(response)
+
+@joern_mcp.tool()
+def find_flows_from_param_index_to_sink_call(
+    source_method_full_name: str,
+    param_index: int,
+    sink_call_name: str,
+    max_paths: int = 20
+) -> list[str]:
+    """Find taint flow paths from a specific parameter (by 0-based index) to calls with a given name.
+    Use this when you know which specific parameter carries tainted data.
+    Each returned string describes one complete path with steps in the form:
+    step0:(type=...|code=...|line=...|id=...) --> step1:(...) --> ...
+    Note: This query may take minutes for large CPGs.
+
+    @param source_method_full_name: Full name of the source method
+    @param param_index: 0-based index of the parameter (0 = first param)
+    @param sink_call_name: Simple method name of the sink call (e.g., 'exec', 'query')
+    @param max_paths: Maximum number of flow paths to return (default 20)
+    @return: List of flow path strings, each showing steps from the parameter to sink
+    """
+    response = joern_remote(
+        f'find_flows_from_param_index_to_sink_call("{source_method_full_name}", {param_index}, "{sink_call_name}", {max_paths})'
+    )
+    return extract_list(response)

--- a/server_tools.sc
+++ b/server_tools.sc
@@ -264,3 +264,91 @@ def get_calls_in_method_by_method_full_name(method_full_name: String): List[Stri
   method.ast.isCall.collect(c => get_call_info_by_id(c.id)).l
 }
 
+// ===== Script version (used to detect mismatch between Python MCP and Joern script) =====
+def get_script_version(): String = "1.1.0"
+
+// ===== Dataflow analysis helper functions =====
+
+def format_flow_step(node: nodes.StoredNode): String = {
+  /*Serialize a single flow step node to a pipe-separated string.
+  Double quotes are replaced with single quotes to avoid breaking Scala List serialization.
+
+  @param node: A CPG node in a flow path
+  @return: Formatted string with type, code, line and id fields
+  */
+  val code = node.property(PropertyNames.CODE, "").toString
+    .replaceAll("[\n\r\t]", " ")
+    .replace("\"", "'")
+    .replace("|", "/")
+  val line = node.propertyOption(PropertyNames.LINE_NUMBER)
+    .map(_.toString).getOrElse("?")
+  s"type=${node.label}|code=${code}|line=${line}|id=${node.id}L"
+}
+
+def format_flow_path(flow: io.joern.dataflowengineoss.language.Path): String = {
+  /*Serialize a complete flow path with steps joined by " --> ".
+
+  @param flow: A dataflow path from source to sink
+  @return: Formatted string with all steps
+  */
+  flow.elements.zipWithIndex.map { case (node, idx) =>
+    s"step${idx}:(${format_flow_step(node)})"
+  }.mkString(" --> ")
+}
+
+// ===== Dataflow query tool functions =====
+
+def find_flows_from_method_params_to_sink_method(
+  source_method_full_name: String,
+  sink_method_full_name: String,
+  max_paths: Int = 20
+): List[String] = {
+  /*Find taint flow paths from all parameters of a source method to calls of a sink method.
+
+  @param source_method_full_name: Full name of the source method
+  @param sink_method_full_name: Full name of the sink method (exact match)
+  @param max_paths: Maximum number of flow paths to return
+  @return: List of flow path strings
+  */
+  val source = cpg.method.fullNameExact(source_method_full_name).parameter
+  val sink = cpg.call.methodFullNameExact(sink_method_full_name).argument
+  sink.reachableByFlows(source).map(format_flow_path).take(max_paths).l
+}
+
+def find_flows_from_source_call_to_sink_call(
+  source_call_name: String,
+  sink_call_name: String,
+  max_paths: Int = 20
+): List[String] = {
+  /*Find taint flow paths from calls named source_call_name to calls named sink_call_name.
+  Uses simple name matching (covers all overloads).
+
+  @param source_call_name: Simple method name of source call (e.g., getStringExtra)
+  @param sink_call_name: Simple method name of sink call (e.g., exec)
+  @param max_paths: Maximum number of flow paths to return
+  @return: List of flow path strings
+  */
+  val source = cpg.call.name(source_call_name)
+  val sink = cpg.call.name(sink_call_name).argument
+  sink.reachableByFlows(source).map(format_flow_path).take(max_paths).l
+}
+
+def find_flows_from_param_index_to_sink_call(
+  source_method_full_name: String,
+  param_index: Int,
+  sink_call_name: String,
+  max_paths: Int = 20
+): List[String] = {
+  /*Find taint flow paths from a specific parameter (0-based index) to calls with a given name.
+
+  @param source_method_full_name: Full name of the source method
+  @param param_index: 0-based index of the parameter
+  @param sink_call_name: Simple method name of the sink call
+  @param max_paths: Maximum number of flow paths to return
+  @return: List of flow path strings
+  */
+  val source = cpg.method.fullNameExact(source_method_full_name).parameter.index(param_index)
+  val sink = cpg.call.name(sink_call_name).argument
+  sink.reachableByFlows(source).map(format_flow_path).take(max_paths).l
+}
+

--- a/server_tools.sc
+++ b/server_tools.sc
@@ -276,12 +276,12 @@ def format_flow_step(node: nodes.StoredNode): String = {
   @param node: A CPG node in a flow path
   @return: Formatted string with type, code, line and id fields
   */
-  val code = node.property(PropertyNames.CODE, "").toString
+  import scala.util.Try
+  val code = Try(node.property[String](PropertyNames.CODE)).getOrElse("")
     .replaceAll("[\n\r\t]", " ")
     .replace("\"", "'")
     .replace("|", "/")
-  val line = node.propertyOption(PropertyNames.LINE_NUMBER)
-    .map(_.toString).getOrElse("?")
+  val line = Try(node.property[Integer](PropertyNames.LINE_NUMBER)).map(_.toString).getOrElse("?")
   s"type=${node.label}|code=${code}|line=${line}|id=${node.id}L"
 }
 

--- a/server_tools_source.sc
+++ b/server_tools_source.sc
@@ -264,3 +264,91 @@ def get_calls_in_method_by_method_full_name(method_full_name: String): List[Stri
   method.ast.isCall.collect(c => get_call_info_by_id(c.id)).l
 }
 
+// ===== Script version (used to detect mismatch between Python MCP and Joern script) =====
+def get_script_version(): String = "1.1.0"
+
+// ===== Dataflow analysis helper functions =====
+
+def format_flow_step(node: nodes.StoredNode): String = {
+  /*Serialize a single flow step node to a pipe-separated string.
+  Double quotes are replaced with single quotes to avoid breaking Scala List serialization.
+
+  @param node: A CPG node in a flow path
+  @return: Formatted string with type, code, line and id fields
+  */
+  val code = node.property(PropertyNames.CODE, "").toString
+    .replaceAll("[\n\r\t]", " ")
+    .replace("\"", "'")
+    .replace("|", "/")
+  val line = node.propertyOption(PropertyNames.LINE_NUMBER)
+    .map(_.toString).getOrElse("?")
+  s"type=${node.label}|code=${code}|line=${line}|id=${node.id}L"
+}
+
+def format_flow_path(flow: io.joern.dataflowengineoss.language.Path): String = {
+  /*Serialize a complete flow path with steps joined by " --> ".
+
+  @param flow: A dataflow path from source to sink
+  @return: Formatted string with all steps
+  */
+  flow.elements.zipWithIndex.map { case (node, idx) =>
+    s"step${idx}:(${format_flow_step(node)})"
+  }.mkString(" --> ")
+}
+
+// ===== Dataflow query tool functions =====
+
+def find_flows_from_method_params_to_sink_method(
+  source_method_full_name: String,
+  sink_method_full_name: String,
+  max_paths: Int = 20
+): List[String] = {
+  /*Find taint flow paths from all parameters of a source method to calls of a sink method.
+
+  @param source_method_full_name: Full name of the source method
+  @param sink_method_full_name: Full name of the sink method (exact match)
+  @param max_paths: Maximum number of flow paths to return
+  @return: List of flow path strings
+  */
+  val source = cpg.method.fullNameExact(source_method_full_name).parameter
+  val sink = cpg.call.methodFullNameExact(sink_method_full_name).argument
+  sink.reachableByFlows(source).map(format_flow_path).take(max_paths).l
+}
+
+def find_flows_from_source_call_to_sink_call(
+  source_call_name: String,
+  sink_call_name: String,
+  max_paths: Int = 20
+): List[String] = {
+  /*Find taint flow paths from calls named source_call_name to calls named sink_call_name.
+  Uses simple name matching (covers all overloads).
+
+  @param source_call_name: Simple method name of source call (e.g., getStringExtra)
+  @param sink_call_name: Simple method name of sink call (e.g., exec)
+  @param max_paths: Maximum number of flow paths to return
+  @return: List of flow path strings
+  */
+  val source = cpg.call.name(source_call_name)
+  val sink = cpg.call.name(sink_call_name).argument
+  sink.reachableByFlows(source).map(format_flow_path).take(max_paths).l
+}
+
+def find_flows_from_param_index_to_sink_call(
+  source_method_full_name: String,
+  param_index: Int,
+  sink_call_name: String,
+  max_paths: Int = 20
+): List[String] = {
+  /*Find taint flow paths from a specific parameter (0-based index) to calls with a given name.
+
+  @param source_method_full_name: Full name of the source method
+  @param param_index: 0-based index of the parameter
+  @param sink_call_name: Simple method name of the sink call
+  @param max_paths: Maximum number of flow paths to return
+  @return: List of flow path strings
+  */
+  val source = cpg.method.fullNameExact(source_method_full_name).parameter.index(param_index)
+  val sink = cpg.call.name(sink_call_name).argument
+  sink.reachableByFlows(source).map(format_flow_path).take(max_paths).l
+}
+

--- a/server_tools_source.sc
+++ b/server_tools_source.sc
@@ -276,12 +276,12 @@ def format_flow_step(node: nodes.StoredNode): String = {
   @param node: A CPG node in a flow path
   @return: Formatted string with type, code, line and id fields
   */
-  val code = node.property(PropertyNames.CODE, "").toString
+  import scala.util.Try
+  val code = Try(node.property[String](PropertyNames.CODE)).getOrElse("")
     .replaceAll("[\n\r\t]", " ")
     .replace("\"", "'")
     .replace("|", "/")
-  val line = node.propertyOption(PropertyNames.LINE_NUMBER)
-    .map(_.toString).getOrElse("?")
+  val line = Try(node.property[Integer](PropertyNames.LINE_NUMBER)).map(_.toString).getOrElse("?")
   s"type=${node.label}|code=${code}|line=${line}|id=${node.id}L"
 }
 


### PR DESCRIPTION
Exposes Joern's dataflow analysis capability via three new MCP tools:                                                    
                                                                                                                           
  - find_flows_from_method_params_to_sink_method — trace all parameters of a method to a specific sink (exact full name    
  match)                                                       
  - find_flows_from_source_call_to_sink_call — trace return values of calls named X to calls named Y (simple name, covers  
  all overloads)                                               
  - find_flows_from_param_index_to_sink_call — trace a specific parameter (0-based index) to a named sink
                                                                                                                           
  All tools accept a max_paths parameter (default 20) to limit result size. Each path is returned as a step-by-step string 
  showing node type, code, line number, and ID.                                                                            
                                                                                                                           
  Also adds get_script_version() to the Scala scripts for future mismatch detection, and fixes a flatgraph API             
  compatibility issue in Joern 4.x.